### PR TITLE
disable gray colors for solarized support

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = function ( results ) {
             messageType,
             chalk.white( message.ruleId || '' ),
             message.message.replace( /\.$/, '' ),
-            '$MARKER$  ' + chalk.underline( chalk.gray( message.filePath + ':' + line + ':' + column ) ) + '$MARKER$  ' + chalk.gray( message.source ) + '$MARKER$  ' + chalk.gray( arrow ) + '$MARKER$'
+            '$MARKER$  ' + chalk.underline( message.filePath + ':' + line + ':' + column ) + '$MARKER$  ' + message.source + '$MARKER$  ' + arrow + '$MARKER$'
           ];
         } ), {
           align: [


### PR DESCRIPTION
unfortunately, `chalk.gray` (ansi "bright black") is used as the default background color by the popular "Solarized" terminal theme, and it therefore renders invisibly when specified without a background color. This PR simply disables the gray color. This was convenient for me and I thought I'd share it, but please feel free to reject with prejudice; I am aware that supporting all non-standard terminal configurations is impossible.