### PR TITLE
Create Executable

### DIFF
--- a/bin/eslint-friendly-formatter
+++ b/bin/eslint-friendly-formatter
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+'use strict';
+
+var spawnSync = require('child_process').spawnSync;
+var path      = require('path');
+var which     = require('npm-which')(process.cwd());
+
+var formatter = path.resolve(__dirname + '/../index.js');
+var eslint    = which.sync('eslint');
+
+var args = [];
+if (process.argv.length > 2) {
+  Array.prototype.push.apply(args, process.argv.slice(2));
+};
+args.push('--format', formatter);
+
+spawnSync(eslint, args, { stdio: 'inherit' });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "index.js",
     "process.js"
   ],
+  "bin": {
+    "eslint-friendly": "bin/eslint-friendly-formatter"
+  },
   "engines": {
     "node": ">=0.10.0"
   },
@@ -57,6 +60,7 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "lodash.assign": "^3.0.0",
+    "npm-which": "^2.0.0",
     "text-table": "^0.2.0"
   },
   "changelogx": {


### PR DESCRIPTION
The idea here is to create an executable which users can use just like the ESLint cli, except it they will be using eslint-friendly-formatter.  The usage is:

```
eslint-friendly code-to-lint.js
```

...which will in fact launch:

```
eslint code-to-lint.js --formatter 'path/to/eslint-friendly-formatter/index.js'
```

Any other command line arguments passed to `eslint-friendly` will also be passed along to eslint.

This works as long as ESLint is installed globally or in the package being linted.  It looks first for eslint in the node_modules of the package, and if one is not found, it will look in parent directories all the way up to global packages.  If no `eslint` is found, an error is thrown.  