### PR TITLE
Allow for null message.source

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ module.exports = function(results) {
           var column = message.column || 0;
 
           var arrow = '';
-          var hasSource = message.source !== undefined && message.source.length < 1000;
+          var hasSource = message.source && message.source.length < 1000;
           if (hasSource) {
             for (var i = 0; i < message.column; i++) {
               if (message.source.charAt(i) === '\t') {

--- a/test/fixtures/fatal/results.json
+++ b/test/fixtures/fatal/results.json
@@ -5,6 +5,7 @@
       {
         "fatal": true,
         "severity": 2,
+        "source": null,
         "message": "Unexpected token {",
         "line": 3,
         "column": 13


### PR DESCRIPTION
Addresses issue #29, where a parsing error causes message source to be null.

This is a naive, defensive fix: i don't know the eslint ecosystem at all and didn't investigate whether `message.source` being null is indicative of a bug upstream.