### PR TITLE
More environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,37 @@ eslint -f node_modules/eslint-formatter-friendly client/**/*.js server/**/*.js -
 
 Same as environment variable `EFF_ABSOLUTE_PATHS`. If set to true the paths will be absolute. Otherwise they will be relative to CWD.
 
+#### --eff-no-source
+
+This flag can be used to disable code snippets/frames from the reported errors/warnings allowing a more compact output.
+
 ### ENV Variables
+
+Some environment variables are identical to the [CLI options](#command-line-options) to allow for a different way of controlling the behavior of the formatter. The CLI option takes precedence, meaning any value given in the environment variable is ignored if the CLI option is specified.
+
+#### `EFF_FILTER`
+
+Works identically to the CLI option [--eff-filter](#--eff-filter).
+
+```bash
+export EFF_FILTER=global-require
+```
+
+#### `EFF_BY_ISSUE`
+
+Works identically to the CLI option [--eff-by-issue](#--eff-by-issue).
+
+```bash
+export EFF_BY_ISSUE=true
+```
+
+#### `EFF_NO_SOURCE`
+
+Works identically to the CLI option [--eff-no-source](#--eff-no-source).
+
+```bash
+export EFF_NO_SOURCE=true
+```
 
 #### `EFF_NO_GRAY`
 
@@ -212,6 +242,26 @@ Some terminals only support clicking on urls, and editors can be configured to r
 
 ```bash
 export EFF_EDITOR_SCHEME=editor://open?file={file}&line={line}&column={column}
+```
+
+#### `EFF_CODE_FRAME_OPTIONS`
+
+This variable allows modifying the format of the code snippets/frames in the reported errors/warnings. The variable is in the form of a stringified JSON object. The [Babel code frame options](https://www.npmjs.com/package/babel-code-frame#options) are allowed as fields in the object.
+
+As an example where only one line of code above and below the error/warning is shown, the following value can be used for the variable:
+
+```bash
+export EFF_CODE_FRAME_OPTIONS='{ "linesAbove": 1, "linesBelow": 1 }'
+```
+
+#### `EFF_RULE_SEARCH_LINK`
+
+When reporting an error/warning, the output will contain a web link to the eslint rule. E.g. `http://eslint.org/docs/rules/global-require`. For rules introduced by an eslint plugin the output will instead contain a link to Google Search, such as `https://google.com/search?q=%40typescript-eslint%2Fprefer-optional-chain`. If a different search engine or a direct link to another webpage is preferred, this environment variable can be used to change the prefix in front of the rule name in the link.
+
+To link to the Duck Duck Go search engine instead, the following example can be used:
+
+```bash
+export EFF_RULE_SEARCH_LINK='https://duckduckgo.com/?q='
 ```
 
 ## [Changelog](./changelog.md)

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ module.exports = function(results) {
   var parsedArgs = minimist(restArgs);
 
   var groupByIssue = parsedArgs['eff-by-issue'] || parseBoolEnvVar('EFF_BY_ISSUE');
-  var filterRule = parsedArgs['eff-filter'];
+  var filterRule = parsedArgs['eff-filter'] || getEnvVar('EFF_FILTER');
   var showSource = !(parsedArgs['eff-no-source'] || parseBoolEnvVar('EFF_NO_SOURCE'));
 
   absolutePathsToFile = clsc(parsedArgs['eff-absolute-paths'], absolutePathsToFile);

--- a/index.js
+++ b/index.js
@@ -55,7 +55,8 @@ var getFileLink = function(_path, line, column) {
 
 var getKeyLink = function(key) {
   var noLinkRules = parseBoolEnvVar('EFF_NO_LINK_RULES');
-  var url = key.indexOf('/') > -1 ? 'https://google.com/search?q=' : 'http://eslint.org/docs/rules/';
+  let searchEngineLink = getEnvVar('EFF_RULE_SEARCH_LINK') || 'https://google.com/search?q=';
+  var url = key.indexOf('/') > -1 ? searchEngineLink : 'http://eslint.org/docs/rules/';
   return (!noLinkRules) ? chalk.underline(subtleLog(url + chalk.white(encodeURIComponent(key)))) : chalk.white(key);
 };
 

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ module.exports = function(results) {
   var restArgs = process.argv.slice(process.argv.indexOf('--') + 1);
   var parsedArgs = minimist(restArgs);
 
-  var groupByIssue = parsedArgs['eff-by-issue'];
+  var groupByIssue = parsedArgs['eff-by-issue'] || parseBoolEnvVar('EFF_BY_ISSUE');
   var filterRule = parsedArgs['eff-filter'];
   var showSource = !(parsedArgs['eff-no-source'] || parseBoolEnvVar('EFF_NO_SOURCE'));
 

--- a/index.js
+++ b/index.js
@@ -84,6 +84,18 @@ var printSummary = function(hash, title, method) {
   return res;
 };
 
+var tryParseJSONObject = function(jsonString) {
+  try {
+      var o = JSON.parse(jsonString);
+      if (o && typeof o === "object") {
+          return o;
+      }
+  }
+  catch (e) { }
+
+  return false;
+};
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -211,9 +223,13 @@ module.exports = function(results) {
         }
 
         function renderSourceCode() {
-          return showSource ? codeFrame(message.fileSource, message.line, message.column, {
-            highlightCode: true
-          }).split('\n').map(l => '   ' + l).join('\n') : '';
+          const codeFrameOptions = tryParseJSONObject(getEnvVar("EFF_CODE_FRAME_OPTIONS")) || { "highlightCode": true };
+          return showSource ? codeFrame(
+              message.fileSource,
+              message.line,
+              message.column,
+              codeFrameOptions
+            ).split('\n').map(l => '   ' + l).join('\n') : '';
         }
 
         function createLine(arr) {

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ module.exports = function(results) {
 
   var groupByIssue = parsedArgs['eff-by-issue'];
   var filterRule = parsedArgs['eff-filter'];
-  var showSource = !parsedArgs['eff-no-source'];
+  var showSource = !(parsedArgs['eff-no-source'] || parseBoolEnvVar('EFF_NO_SOURCE'));
 
   absolutePathsToFile = clsc(parsedArgs['eff-absolute-paths'], absolutePathsToFile);
 


### PR DESCRIPTION
Fixes #47 by adding environment variables corresponding to the existing CLI options as well as adding a couple of extra variables to allow more control of the output - `EFF_RULE_SEARCH_LINK` and `EFF_CODE_FRAME_OPTIONS`.